### PR TITLE
- bugfix : fix the path of the directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN cd /home \
 COPY . /cpp/src/project/ 
 WORKDIR /cpp/src/project/
 
-RUN cmake -Bbuild -H. && cmake --build bin
+RUN cmake -Bbuild -H. && cmake --build build
 
 FROM ubuntu:bionic 
-COPY --from=build /cpp/src/project/bin/websocket-chat-server /app/
+COPY --from=build /cpp/src/project/build/websocket-chat-server /app/
 COPY --from=build /cpp/src/project/chat_client.html /app/wwwroot/index.html
 
 ENTRYPOINT ["/app/websocket-chat-server", "0.0.0.0", "8080", "/app/wwwroot"]


### PR DESCRIPTION
The build directory is set to build` project due to `cmake -B` part of command. Hence the next commands should refer to `build` directory too.