### PR TITLE
Use of std::queue instead of std::vector for outgoing messages

### DIFF
--- a/websocket_session.cpp
+++ b/websocket_session.cpp
@@ -87,7 +87,7 @@ websocket_session::
 send(std::shared_ptr<std::string const> const& ss)
 {
     // Always add to queue
-    queue_.push_back(ss);
+    queue_.push(ss);
 
     // Are we already writing?
     if(queue_.size() > 1)
@@ -112,7 +112,7 @@ on_write(error_code ec, std::size_t)
         return fail(ec, "write");
 
     // Remove the string from the queue
-    queue_.erase(queue_.begin());
+    queue_.pop();
 
     // Send the next message if any
     if(! queue_.empty())

--- a/websocket_session.hpp
+++ b/websocket_session.hpp
@@ -17,7 +17,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
-#include <vector>
+#include <queue>
 
 // Forward declaration
 class shared_state;
@@ -29,7 +29,7 @@ class websocket_session : public std::enable_shared_from_this<websocket_session>
     beast::flat_buffer buffer_;
     websocket::stream<tcp::socket> ws_;
     std::shared_ptr<shared_state> state_;
-    std::vector<std::shared_ptr<std::string const>> queue_;
+    std::queue<std::shared_ptr<std::string const>> queue_;
 
     void fail(error_code ec, char const* what);
     void on_accept(error_code ec);


### PR DESCRIPTION
More natural for this task and more efficient when removing the first element.