### PR TITLE
Adding missing iostream header

### DIFF
--- a/websocket_session.cpp
+++ b/websocket_session.cpp
@@ -8,6 +8,7 @@
 //
 
 #include "websocket_session.hpp"
+#include <iostream>
 
 websocket_session::
 websocket_session(


### PR DESCRIPTION
The cerr usage in here did not compile, so I added the iostream header
for it.